### PR TITLE
Update composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
         },
         "flarum-locale": {
             "code": "ja",
-            "title": "Japanese"
+            "title": "日本語"
         }
     }
 }


### PR DESCRIPTION
The language name in the drop-down menu should be written in Japanese.
This will make it easier for users to find it (Fix #11).