### PR TITLE
Release `v3.6.2`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,24 @@ CHANGELOG
 =========
 
 
+3.6.2 (XXXX-XX-XX)
+------------------
+
+**更新内容**:
+
+* Flarum coreの翻訳を更新.
+
+
+**拡張機能の翻訳を更新**:
+
+* [`flarum/lock`](https://github.com/flarum/lock)
+* [`flarum/sticky`](https://github.com/flarum/sticky)
+* [`flarum/tags`](https://github.com/flarum/tags)
+
+
+全ての更新内容:[v3.6.1...v3.6.2](https://github.com/flarum-lang/japanese/compare/v3.6.1...v3.6.2).
+
+
 3.6.1 (2023-02-19)
 ------------------
 


### PR DESCRIPTION
This is a draft of changelog for the `v3.6.2` release.
Here you can find all related translations changes: [v3.6.1...master](https://github.com/flarum-lang/japanese/compare/v3.6.1...master).

> ### ⚠️ Do not merge this pull request manually ⚠️
> 
> You should **[approve](https://github.com/rob006-software/flarum-translations/wiki/How-to-approve-release-pull-request)** this pull request instead. After approving, I will automatically update it (release date needs to be adjusted), merge, and tag a new release. You can read more about the process on [forum](https://discuss.flarum.org/d/20807-simplify-translation-process-with-weblate/76).

<details>
<summary>Show release notes preview</summary>

## v3.6.2

<!-- release-notes-begin -->
**更新内容**:

* Flarum coreの翻訳を更新.


**拡張機能の翻訳を更新**:

* [`flarum/lock`](https://github.com/flarum/lock)
* [`flarum/sticky`](https://github.com/flarum/sticky)
* [`flarum/tags`](https://github.com/flarum/tags)


全ての更新内容:[v3.6.1...v3.6.2](https://github.com/flarum-lang/japanese/compare/v3.6.1...v3.6.2).



<!-- release-notes-end -->

</details>